### PR TITLE
Check that there is at least one log number

### DIFF
--- a/log_download_program.cpp
+++ b/log_download_program.cpp
@@ -231,6 +231,11 @@ void Log_Download_Program::parse_arguments(int argc, char *argv[])
         }
     }
 
+    if(optind==argc){
+        ::fprintf(stderr, "Failed to parse log numbers");
+        abort();
+    }
+
     for (auto index = optind; index < argc; index++) {
         uint16_t n = atoi(argv[index]);
         if (n == 0) {

--- a/log_download_program.cpp
+++ b/log_download_program.cpp
@@ -231,7 +231,7 @@ void Log_Download_Program::parse_arguments(int argc, char *argv[])
         }
     }
 
-    if(optind==argc){
+    if(optind==argc && !list){
         ::fprintf(stderr, "Failed to parse log numbers");
         abort();
     }


### PR DESCRIPTION
Error case : 
./log-download -s /dev/ttyACM0
Resulting in segfault if no log number is given. Handle the error by checking that optind is less than argc.